### PR TITLE
Add new

### DIFF
--- a/clientapp/components/admin/game/TeamManageView.tsx
+++ b/clientapp/components/admin/game/TeamManageView.tsx
@@ -68,7 +68,9 @@ export type TeamModel = {
         user_id: string
     }[],
     status: ParticipationStatus,
-    score: number
+    score: number,
+    group_id: number | null,
+    group_name: string | null
 }
 
 interface ConfirmDialogProps {
@@ -261,6 +263,7 @@ export function TeamManageView(
     
     // 从scoreBoardModel中通过队伍名称查找队伍
     const team = scoreBoardModel.teams.find(team => team.team_name === teamName);
+    console.log(team)
     
     // 如果找到队伍且有group_id，则通过group_id查找对应的分组名称
     if (team && team.group_id) {
@@ -301,10 +304,11 @@ export function TeamManageView(
             header: t("events.filter.team"),
             cell: ({ row }) => {
                 const avatar_url = row.original.team_avatar;
+                const groupName = row.original.group_name || "未分组";
                 return (
                     <div className="flex gap-3 items-center">
                         <AvatarUsername avatar_url={avatar_url} username={row.getValue("team_name") as string} />
-                        {row.getValue("team_name")}-{getTeamGroupName(row.getValue("team_name"))}
+                        {row.getValue("team_name")}-{groupName}
                     </div>
                 )
             },
@@ -493,7 +497,9 @@ export function TeamManageView(
                     user_id: member.user_id
                 })),
                 status: item.status,
-                score: item.score
+                score: item.score,
+                group_id: item.group_id || null,
+                group_name: item.group_name || null
             }));
             setData(formattedData);
         })

--- a/src/controllers/admin_team_controller.go
+++ b/src/controllers/admin_team_controller.go
@@ -26,7 +26,7 @@ func AdminListTeams(c *gin.Context) {
 		return
 	}
 
-	query := dbtool.DB().Where("game_id = ?", payload.GameID)
+	query := dbtool.DB().Preload("GameGroup").Where("game_id = ?", payload.GameID)
 
 	// 如果有搜索关键词，添加搜索条件
 	if payload.Search != "" {
@@ -120,6 +120,13 @@ func AdminListTeams(c *gin.Context) {
 			Members:    tmpMembers,
 			Status:     team.TeamStatus,
 			Score:      team.TeamScore,
+			GroupID:    team.GroupID,
+			GroupName:  func() *string {
+				if team.GameGroup != nil {
+					return &team.GameGroup.GroupName
+				}
+				return nil
+			}(),
 		})
 	}
 

--- a/src/controllers/admin_team_controller.go
+++ b/src/controllers/admin_team_controller.go
@@ -26,7 +26,7 @@ func AdminListTeams(c *gin.Context) {
 		return
 	}
 
-	query := dbtool.DB().Preload("GameGroup").Where("game_id = ?", payload.GameID)
+	query := dbtool.DB().Preload("Group").Where("game_id = ?", payload.GameID)
 
 	// 如果有搜索关键词，添加搜索条件
 	if payload.Search != "" {
@@ -122,8 +122,8 @@ func AdminListTeams(c *gin.Context) {
 			Score:      team.TeamScore,
 			GroupID:    team.GroupID,
 			GroupName:  func() *string {
-				if team.GameGroup != nil {
-					return &team.GameGroup.GroupName
+				if team.Group != nil {
+					return &team.Group.GroupName
 				}
 				return nil
 			}(),

--- a/src/webmodels/response_models.go
+++ b/src/webmodels/response_models.go
@@ -148,6 +148,8 @@ type AdminListTeamItem struct {
 	Members    []AdminSimpleTeamMemberInfo `json:"members"`
 	Status     models.ParticipationStatus  `json:"status"`
 	Score      float64                     `json:"score"`
+	GroupID    *int64                      `json:"group_id"`
+	GroupName  *string                     `json:"group_name"`
 }
 
 type TimeLineScoreItem struct {

--- a/team_group_query.go
+++ b/team_group_query.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// 数据库连接配置
+const (
+	host     = "localhost"
+	port     = 5432
+	user     = "your_username"
+	password = "your_password"
+	dbname   = "a1ctf"
+)
+
+// Team 模型结构体
+type Team struct {
+	TeamID  int64  `gorm:"column:team_id;primaryKey"`
+	GameID  int64  `gorm:"column:game_id"`
+	GroupID *int64 `gorm:"column:group_id"`
+	// 其他字段...
+}
+
+// GameGroup 模型结构体
+type GameGroup struct {
+	GroupID   int64  `gorm:"column:group_id;primaryKey"`
+	GameID    int64  `gorm:"column:game_id"`
+	GroupName string `gorm:"column:group_name"`
+	// 其他字段...
+}
+
+// 查询结果结构体
+type TeamGroupResult struct {
+	TeamID    int64   `json:"team_id"`
+	GameID    int64   `json:"game_id"`
+	GroupID   *int64  `json:"group_id"`
+	GroupName *string `json:"group_name"`
+}
+
+func main() {
+	// 连接数据库
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		host, port, user, password, dbname)
+	
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		log.Fatal("连接数据库失败:", err)
+	}
+
+	// 示例查询参数
+	gameID := int64(1)
+	teamID := int64(100)
+
+	// 方法1: 使用原生SQL查询
+	result1 := queryWithRawSQL(db, gameID, teamID)
+	fmt.Printf("原生SQL查询结果: %+v\n", result1)
+
+	// 方法2: 使用GORM JOIN查询
+	result2 := queryWithGORMJoin(db, gameID, teamID)
+	fmt.Printf("GORM JOIN查询结果: %+v\n", result2)
+
+	// 方法3: 使用GORM预加载查询
+	result3 := queryWithGORMPreload(db, gameID, teamID)
+	fmt.Printf("GORM预加载查询结果: %+v\n", result3)
+
+	// 方法4: 分步查询
+	result4 := queryStepByStep(db, gameID, teamID)
+	fmt.Printf("分步查询结果: %+v\n", result4)
+}
+
+// 方法1: 使用原生SQL查询
+func queryWithRawSQL(db *gorm.DB, gameID, teamID int64) *TeamGroupResult {
+	var result TeamGroupResult
+	
+	sql := `
+		SELECT 
+			t.team_id,
+			t.game_id,
+			t.group_id,
+			gg.group_name
+		FROM teams t
+		LEFT JOIN game_groups gg ON t.group_id = gg.group_id
+		WHERE t.game_id = ? AND t.team_id = ?
+	`
+	
+	err := db.Raw(sql, gameID, teamID).Scan(&result).Error
+	if err != nil {
+		log.Printf("原生SQL查询失败: %v", err)
+		return nil
+	}
+	
+	return &result
+}
+
+// 方法2: 使用GORM JOIN查询
+func queryWithGORMJoin(db *gorm.DB, gameID, teamID int64) *TeamGroupResult {
+	var result TeamGroupResult
+	
+	err := db.Table("teams t").
+		Select("t.team_id, t.game_id, t.group_id, gg.group_name").
+		Joins("LEFT JOIN game_groups gg ON t.group_id = gg.group_id").
+		Where("t.game_id = ? AND t.team_id = ?", gameID, teamID).
+		Scan(&result).Error
+	
+	if err != nil {
+		log.Printf("GORM JOIN查询失败: %v", err)
+		return nil
+	}
+	
+	return &result
+}
+
+// 方法3: 使用GORM预加载查询
+func queryWithGORMPreload(db *gorm.DB, gameID, teamID int64) *TeamGroupResult {
+	var team Team
+	
+	// 定义带关联的Team结构体
+	type TeamWithGroup struct {
+		Team
+		Group *GameGroup `gorm:"foreignKey:GroupID;references:GroupID"`
+	}
+	
+	var teamWithGroup TeamWithGroup
+	
+	err := db.Preload("Group").
+		Where("game_id = ? AND team_id = ?", gameID, teamID).
+		First(&teamWithGroup).Error
+	
+	if err != nil {
+		log.Printf("GORM预加载查询失败: %v", err)
+		return nil
+	}
+	
+	result := &TeamGroupResult{
+		TeamID:  teamWithGroup.TeamID,
+		GameID:  teamWithGroup.GameID,
+		GroupID: teamWithGroup.GroupID,
+	}
+	
+	if teamWithGroup.Group != nil {
+		result.GroupName = &teamWithGroup.Group.GroupName
+	}
+	
+	return result
+}
+
+// 方法4: 分步查询
+func queryStepByStep(db *gorm.DB, gameID, teamID int64) *TeamGroupResult {
+	// 第一步：查询team获取group_id
+	var team Team
+	err := db.Where("game_id = ? AND team_id = ?", gameID, teamID).First(&team).Error
+	if err != nil {
+		log.Printf("查询team失败: %v", err)
+		return nil
+	}
+	
+	result := &TeamGroupResult{
+		TeamID:  team.TeamID,
+		GameID:  team.GameID,
+		GroupID: team.GroupID,
+	}
+	
+	// 第二步：如果有group_id，查询group_name
+	if team.GroupID != nil {
+		var gameGroup GameGroup
+		err := db.Where("group_id = ?", *team.GroupID).First(&gameGroup).Error
+		if err != nil {
+			log.Printf("查询game_group失败: %v", err)
+		} else {
+			result.GroupName = &gameGroup.GroupName
+		}
+	}
+	
+	return result
+}
+
+// 批量查询多个team的group_name
+func queryMultipleTeams(db *gorm.DB, gameID int64, teamIDs []int64) []TeamGroupResult {
+	var results []TeamGroupResult
+	
+	sql := `
+		SELECT 
+			t.team_id,
+			t.game_id,
+			t.group_id,
+			gg.group_name
+		FROM teams t
+		LEFT JOIN game_groups gg ON t.group_id = gg.group_id
+		WHERE t.game_id = ? AND t.team_id IN ?
+		ORDER BY t.team_id
+	`
+	
+	err := db.Raw(sql, gameID, teamIDs).Scan(&results).Error
+	if err != nil {
+		log.Printf("批量查询失败: %v", err)
+		return nil
+	}
+	
+	return results
+}
+
+// 表名设置
+func (Team) TableName() string {
+	return "teams"
+}
+
+func (GameGroup) TableName() string {
+	return "game_groups"
+}


### PR DESCRIPTION
fix(judge_job): 修复排行榜通知中队伍分组信息显示问题
修改了处理排行榜通知时的队伍名称显示逻辑，当队伍有分组时，在队伍名称后追加分组名称。这解决了之前通知中未显示队伍分组信息的问题。

fix(admin_team_controller): 修复团队列表查询中关联组名的字段错误
将GameGroup字段更正为Group以匹配数据库模型，确保团队列表能正确显示关联组名

feat(团队管理): 添加团队分组信息显示功能
在团队管理相关组件中添加团队分组信息的显示功能，包括：
1. 在响应模型中添加GroupID和GroupName字段
2. 修改查询逻辑预加载GameGroup关联数据
3. 更新前端组件显示分组信息
4. 新增团队分组查询工具文件